### PR TITLE
Package name separated from source folder name

### DIFF
--- a/config/CConfig.py
+++ b/config/CConfig.py
@@ -38,6 +38,9 @@
 #
 # --------------------------------------------------------------------------------------------------------------
 #
+# 11.03.2022 / XC-CT/ECA3-Queckenstedt
+# Package name separated from source folder name
+#
 # 22.02.2022 / XC-CT/ECA3-Queckenstedt
 # Usage of %RobotPythonPath% exchanged by sys.executable
 #
@@ -85,8 +88,9 @@ class CConfig():
         self.__dictConfig['sReferencePath'] = self.__sReferencePath # only to have the possibility to print out all values only with help of 'self.__dictConfig'
 
         # 1. basic setup stuff
-        self.__dictConfig['sPackageName']                = "RobotFramework_Testsuites"
-        self.__dictConfig['sVersion']                    = "0.0.1"
+        self.__dictConfig['sPackageName']                = "robotframework-testsuitesmanagement"
+        self.__dictConfig['sImportName']                 = "RobotFramework_Testsuites"
+        self.__dictConfig['sVersion']                    = "0.0.2"
         self.__dictConfig['sAuthor']                     = "ROBFW-AIO Team"
         self.__dictConfig['sAuthorEMail']                = "Thomas.Pollerspoeck@de.bosch.com"
         self.__dictConfig['sDescription']                = "This package together with the JsonPreprocessor package provides functionality to manage Robotframework testsuites"
@@ -99,7 +103,7 @@ class CConfig():
         self.__dictConfig['sDevelopmentStatus']          = "Development Status :: 4 - Beta"
         self.__dictConfig['sIntendedAudience']           = "Intended Audience :: Developers"
         self.__dictConfig['sTopic']                      = "Topic :: Software Development"
-        self.__dictConfig['arInstallRequires']            = ['sphinx','pypandoc','colorama']
+        self.__dictConfig['arInstallRequires']           = ['sphinx','pypandoc','colorama']
 
 
         # 2. certain folder and executables (things that requires computation)
@@ -136,14 +140,14 @@ class CConfig():
 
         if sPlatformSystem == "Windows":
             SPHINXBUILD                = f"{sPythonPath}/Scripts/sphinx-build.exe"
-            sInstalledPackageFolder    = f"{sPythonPath}/Lib/site-packages/" + self.__dictConfig['sPackageName']
-            sInstalledPackageDocFolder = f"{sPythonPath}/Lib/site-packages/" + self.__dictConfig['sPackageName'] + "_doc"
+            sInstalledPackageFolder    = f"{sPythonPath}/Lib/site-packages/" + self.__dictConfig['sImportName']
+            sInstalledPackageDocFolder = f"{sPythonPath}/Lib/site-packages/" + self.__dictConfig['sImportName'] + "_doc"
             sLaTeXInterpreter          = os.path.normpath(os.path.expandvars("%ROBOTLATEXPATH%/miktex/bin/x64/pdflatex.exe"))
 
         elif sPlatformSystem == "Linux":
             SPHINXBUILD                = f"{sPythonPath}/sphinx-build"
-            sInstalledPackageFolder    = f"{sPythonPath}/../lib/python3.9/site-packages/" + self.__dictConfig['sPackageName']
-            sInstalledPackageDocFolder = f"{sPythonPath}/../lib/python3.9/site-packages/" + self.__dictConfig['sPackageName'] + "_doc"
+            sInstalledPackageFolder    = f"{sPythonPath}/../lib/python3.9/site-packages/" + self.__dictConfig['sImportName']
+            sInstalledPackageDocFolder = f"{sPythonPath}/../lib/python3.9/site-packages/" + self.__dictConfig['sImportName'] + "_doc"
             sLaTeXInterpreter          = os.path.normpath(os.path.expandvars("${ROBOTLATEXPATH}/miktex/bin/x64/pdflatex"))
 
         else:
@@ -198,9 +202,10 @@ class CConfig():
 
         self.__dictConfig['sSetupBuildFolder']       = os.path.normpath(self.__sReferencePath + "/build")
         self.__dictConfig['sSetupBuildLibFolder']    = os.path.normpath(self.__sReferencePath + "/build/lib")
-        self.__dictConfig['sSetupBuildLibDocFolder'] = os.path.normpath(self.__sReferencePath + "/build/lib/" + self.__dictConfig['sPackageName'] + "_doc")
+        self.__dictConfig['sSetupBuildLibDocFolder'] = os.path.normpath(self.__sReferencePath + "/build/lib/" + self.__dictConfig['sImportName'] + "_doc")
         self.__dictConfig['sSetupDistFolder']        = os.path.normpath(self.__sReferencePath + "/dist")
-        self.__dictConfig['sEggInfoFolder']          = os.path.normpath(self.__sReferencePath + "/" + self.__dictConfig['sPackageName'] + ".egg-info")
+        sLocalEggFolderNamePart = self.__dictConfig['sPackageName'].replace("-", "_") # to be aligned to the way the setuptools modify the name also
+        self.__dictConfig['sEggInfoFolder']          = os.path.normpath(self.__sReferencePath + "/" + sLocalEggFolderNamePart + ".egg-info")
 
         print()
         print(f"Running under {sPlatformSystem} ({sOSName})")

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,9 @@
 #
 # --------------------------------------------------------------------------------------------------------------
 #
+# 11.03.2022 / XC-CT/ECA3-Queckenstedt
+# 'package_dir' added
+#
 # 07.03.2022 / XC-CT/ECA3-Queckenstedt
 # Fixed 'packages' listing and the installation of additional files (json)
 #
@@ -114,7 +117,7 @@ class ExtendedInstallCommand(install):
             print()
             print(COLBY + "Extended setup step 4/5: install.run(self)") # creates the build folder .\build
             print()
-            install.run(self) # TODO: What does install.run(self) return? How to realize error handling?
+            install.run(self)
             print()
             if 'bdist_wheel' in listCmdArgs:
                 print(COLBY + "Extended setup step 5/5: Add html documentation to local wheel folder inside build")
@@ -214,11 +217,13 @@ setuptools.setup(
     long_description_content_type = str(oRepositoryConfig.Get('sLongDescriptionContentType')),
     url = str(oRepositoryConfig.Get('sURL')),
 
-    packages = [str(oRepositoryConfig.Get('sPackageName')),
-                str(oRepositoryConfig.Get('sPackageName')) + ".Config",
-                str(oRepositoryConfig.Get('sPackageName')) + ".Keywords",
-                str(oRepositoryConfig.Get('sPackageName')) + ".Utils",
-                str(oRepositoryConfig.Get('sPackageName')) + ".Utils.Events"],
+    packages = [str(oRepositoryConfig.Get('sImportName')),
+                str(oRepositoryConfig.Get('sImportName')) + ".Config",
+                str(oRepositoryConfig.Get('sImportName')) + ".Keywords",
+                str(oRepositoryConfig.Get('sImportName')) + ".Utils",
+                str(oRepositoryConfig.Get('sImportName')) + ".Utils.Events"],
+
+    package_dir = {str(oRepositoryConfig.Get('sPackageName')) : str(oRepositoryConfig.Get('sImportName'))},
 
     include_package_data = True,
 


### PR DESCRIPTION
Question: Do we need the JsonPreprocessor package to be a part of list 'arInstallRequires'?