### PR TITLE
Added local configuration feature.

### DIFF
--- a/RobotFramework_Testsuites/Config/CConfig.py
+++ b/RobotFramework_Testsuites/Config/CConfig.py
@@ -121,6 +121,7 @@ class CConfig():
     sTestcasePath     = ''
     sMaxVersion       = ''
     sMinVersion       = ''
+    lLocalConfig      = []
     rConfigFiles   = CStruct(
                                 sLevel1 = False,
                                 sLevel2 = False,
@@ -373,7 +374,7 @@ class CConfig():
             BuiltIn().set_global_variable("${CONFIG}",oJsonCfgData)
         self.bConfigLoaded = True
         
-    def updateCfg(sUpdateCfgFile):
+    def updateCfg(self, sUpdateCfgFile):
         '''
 **Method: updateCfg**
 
@@ -394,7 +395,7 @@ class CConfig():
         '''
         oJsonPreprocessor = CJsonPreprocessor(syntax="python", currentCfg=CConfig.oConfigParams)
         try:
-            oUpdateParams = oJsonPreprocessor.jsonLoad(CConfig.__sNormalizePath(os.path.abspath(sUpdateCfgFile)))
+            oUpdateParams = oJsonPreprocessor.jsonLoad(CConfig.__sNormalizePath(CConfig, os.path.abspath(sUpdateCfgFile)))
         except Exception as error:
             CConfig.bLoadedCfg = False
             CConfig.sLoadedCfgError = str(error)
@@ -416,7 +417,7 @@ class CConfig():
         
         BuiltIn().set_global_variable("${CONFIG}", oTmpJsonCfgData)
         del oTmpJsonCfgData
-        CConfig.__updateGlobalVariable(CConfig)
+        self.__updateGlobalVariable()
         
     def __setGlobalVariable(self, key, value):
         '''

--- a/RobotFramework_Testsuites/Keywords/CSetup.py
+++ b/RobotFramework_Testsuites/Keywords/CSetup.py
@@ -108,6 +108,13 @@ class CSetupKeywords(object):
         else:
             logger.info('Running with configuration level: 4')
 
+        if RobotFramework_Testsuites.CTestsuitesCfg.oConfig.lLocalConfig:
+            for localConfig in RobotFramework_Testsuites.CTestsuitesCfg.oConfig.lLocalConfig:
+                try:
+                    RobotFramework_Testsuites.CTestsuitesCfg.oConfig.updateCfg(localConfig)
+                except:
+                    logger.warn("Could not load local configuration file: %s " % localConfig)
+
         RobotFramework_Testsuites.CTestsuitesCfg.oConfig.verifyRbfwVersion()
         logger.info('Suite Path: %s' %(RobotFramework_Testsuites.CTestsuitesCfg.oConfig.sTestcasePath))
         logger.info('CfgFile Path: %s' %(RobotFramework_Testsuites.CTestsuitesCfg.oConfig.sTestCfgFile))

--- a/RobotFramework_Testsuites/Utils/LibListener.py
+++ b/RobotFramework_Testsuites/Utils/LibListener.py
@@ -14,6 +14,7 @@
 
 from inspect import stack
 import os
+import re
 import RobotFramework_Testsuites
 from RobotFramework_Testsuites.Config import CConfig
 
@@ -81,6 +82,16 @@ class LibListener(object):
             RobotFramework_Testsuites.CTestsuitesCfg.oConfig.sRootSuiteName = test_suite.name
             RobotFramework_Testsuites.CTestsuitesCfg.oConfig.iTotalTestcases = test_suite.test_count
             
+            if '${localconfig}' in BuiltIn().get_variables()._keys:
+                if re.match('^\s*$', BuiltIn().get_variable_value('${LOCAL_CONFIG}')):
+                    logger.error("local_config input must not be empty!!!")
+                else:
+                    RobotFramework_Testsuites.CTestsuitesCfg.oConfig.lLocalConfig.append(BuiltIn().get_variable_value('${LOCAL_CONFIG}').strip())
+            elif os.path.isdir(os.environ['ROBOT_LOCAL_CONFIG']):
+                for file in os.listdir(os.environ['ROBOT_LOCAL_CONFIG']):
+                    if file.endswith('.json'):
+                        RobotFramework_Testsuites.CTestsuitesCfg.oConfig.lLocalConfig.append(os.path.join(os.environ['ROBOT_LOCAL_CONFIG'], file))
+
             if '${variant}' in BuiltIn().get_variables()._keys:
                 RobotFramework_Testsuites.CTestsuitesCfg.oConfig.sConfigName = BuiltIn().get_variable_value('${VARIANT}')
             if '${swversion}' in BuiltIn().get_variables()._keys:

--- a/packagedoc/additional_docs/Description.rst
+++ b/packagedoc/additional_docs/Description.rst
@@ -104,7 +104,7 @@ The 4 different configuration levels helps users more convenient to configure Ro
 
 * Level 2 supports users loading configuration file base on variant name.
 
-* Level 3 supports users creating different separated configuration files for indiviual robot testsuite files.
+* Level 3 supports users creating different separated configuration files for individual robot testsuite files.
 
 * Level 4 supports users practicing to learn RobotFramework AIO.
 
@@ -161,7 +161,7 @@ Then the path of ``variants_cfg.json`` file has to be added as input parameter o
 in ``Suite Setup`` of a testsuite.
 
 In case of user wants to set configuration level 2 for entire RobotFramework test project instead of 
-indiviual robot testsuite file, ``__init__.robot`` file has to be created at the highest folder of 
+indivdiual robot testsuite file, ``__init__.robot`` file has to be created at the highest folder of 
 RobotFrameowork test project, and the path of ``variants_cfg.json`` file has to be added as input parameter of 
 ``testsuites.testsuite_setup`` in ``Suite Setup`` of the ``__init__.robot`` file.
 
@@ -189,6 +189,31 @@ robot execution will use the configuration level 4 by default.
 The default configuration file (``robot_config.json``) in installation directory:
 
 ``\RobotFramework_Testsuites\Config\robot_config.json``
+
+**Local configuration**
+~~~~~~~~~~~~~~~~~~~~~~~
+
+In case the robot test project runs on many different test setups, each test setup has some distinguished configuration 
+parameters. So this feature supports users create the local configuration file to override or add new parameters which 
+are applied for indivdiual test setup.
+
+There are 2 ways to load the local configuration for robot run:
+
+**Load local configuration via input parameter of robot command**
+
+User can address the local configuration file when executing robot testsuite with input parameter 
+``--variable local_config:"<path_to_localconfig_file>"``
+
+**Load local configuration in default directory**
+
+After installed RobotFramework AIO, the ``localconfig`` directory is created in:
+
+* **Windows:** ``C:\RobotTest\localconfig``
+
+* **Ubuntu:** ``/home/<user>/RobotTest/localconfig``
+
+Users can create the local json configuration files in this directory, then some configuration parameters will be overridden 
+by the data in these local configuration files.
 
 **Access to configuration parameters**
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/packagedoc/additional_docs/Description.rst
+++ b/packagedoc/additional_docs/Description.rst
@@ -215,6 +215,9 @@ After installed RobotFramework AIO, the ``localconfig`` directory is created in:
 Users can create the local json configuration files in this directory, then some configuration parameters will be overridden 
 by the data in these local configuration files.
 
+**Note:** In case loading local configuration via input parameter of robot command is using, the local configuration files 
+which are loacted in ``/RobotTest/localconfig`` will be ignored.
+
 **Access to configuration parameters**
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Hello Thomas,

I have just implemented local configuration feature for RobotFramework AIO, this feature will work as below description.

There are 2 ways to load the local configuration for robot run:
1. Load local configuration via input parameter of robot command
    User can address the local configuration file when executing robot testsuite with input parameter --variable local_config:<path_to_localconfig_file>

2. Load local configuration in default directory
    Users can create the local json configuration files in /RotbotTest/localconfig, then some configuration parameters will be overridden by the data in these local configuration files.
    My current implementation is I allow users can create more than 1 local config file in /RotbotTest/localconfig, it means all json files which are created in /RotbotTest/localconfig will be updated as local configuration.

Note: In case the first way - Load local configuration via input parameter of robot command - is using, the second way if any will be ignored.

Thank you,
Son