### PR TITLE
Raise error message if variant variable is set when running with conf…

### DIFF
--- a/RobotFramework_TestsuitesManagement/Config/CConfig.py
+++ b/RobotFramework_TestsuitesManagement/Config/CConfig.py
@@ -279,11 +279,25 @@ class CConfig():
             elif not self.rConfigFiles.sLevel2 and not self.rConfigFiles.sLevel3:
                 return
         
-        if self.rConfigFiles.sLevel1 and self.sTestCfgFile == '':
-            logger.error("The config_file input parameter is empty!!!")
-            raise Exception("The config_file input parameter is empty!!!")
-        elif not (os.path.isfile(self.sTestCfgFile)):
-           raise Exception("Did not find configuration file: '%s'!" % self.sTestCfgFile)
+        if self.rConfigFiles.sLevel1:
+            if self.sConfigName != 'default':
+                errorMessage = f"RobotFramework-TestsuitesManagement detected that: \n \
+            - User is using configuration level 1 with configuration file '{self.sTestCfgFile}'. \n \
+            - The variant variable is also set with variant name '{self.sConfigName}' which is used for configuration \
+level 2 with variant configuration file. \n \
+        Please remove input parameter '--variable variant:{self.sConfigName}' out of the robot run comnand!!! \n"
+                logger.error(errorMessage)
+                BuiltIn().unknown(errorMessage)
+
+            if self.sTestCfgFile == '':
+                errorMessage = "The config_file input parameter is empty!!!"
+                logger.error(errorMessage)
+                BuiltIn().unknown(errorMessage)
+
+        if not os.path.isfile(self.__sNormalizePath(os.path.abspath(self.sTestCfgFile))):
+            errorMessage = f"Did not find configuration file: '{self.sTestCfgFile}'!"
+            logger.error(errorMessage)
+            BuiltIn().unknown(errorMessage)
         
         robotCoreData = BuiltIn().get_variables()
         ROBFW_AIO_Data = {}

--- a/RobotFramework_TestsuitesManagement/Utils/LibListener.py
+++ b/RobotFramework_TestsuitesManagement/Utils/LibListener.py
@@ -86,7 +86,7 @@ class LibListener(object):
             RobotFramework_TestsuitesManagement.CTestsuitesCfg.oConfig.iTotalTestcases = test_suite.test_count
             
             if '${variant}' in BuiltIn().get_variables()._keys:
-                RobotFramework_TestsuitesManagement.CTestsuitesCfg.oConfig.sConfigName = BuiltIn().get_variable_value('${VARIANT}')
+                RobotFramework_TestsuitesManagement.CTestsuitesCfg.oConfig.sConfigName = BuiltIn().get_variable_value('${VARIANT}').strip()
             if '${swversion}' in BuiltIn().get_variables()._keys:
                 RobotFramework_TestsuitesManagement.CTestsuitesCfg.oConfig.rMetaData.sVersionSW = BuiltIn().get_variable_value('${SW_VERSION}')
             if '${hwversion}' in BuiltIn().get_variables()._keys:
@@ -96,7 +96,7 @@ class LibListener(object):
             if '${configfile}' in BuiltIn().get_variables()._keys:
                 RobotFramework_TestsuitesManagement.CTestsuitesCfg.oConfig.rConfigFiles.sLevel1 = True
                 RobotFramework_TestsuitesManagement.CTestsuitesCfg.oConfig.rConfigFiles.sLevel4 = False
-                RobotFramework_TestsuitesManagement.CTestsuitesCfg.oConfig.sTestCfgFile = BuiltIn().get_variable_value('${CONFIG_FILE}')
+                RobotFramework_TestsuitesManagement.CTestsuitesCfg.oConfig.sTestCfgFile = BuiltIn().get_variable_value('${CONFIG_FILE}').strip()
                 try:
                     RobotFramework_TestsuitesManagement.CTestsuitesCfg.oConfig.loadCfg(RobotFramework_TestsuitesManagement.CTestsuitesCfg.oConfig)
                 except:


### PR DESCRIPTION
…ig level 1

Hello Thomas,

The error message:

[ ERROR ] RobotFramework-TestsuitesManagement detected that:
             - User is using configuration level 1 with configuration file 'C:\Users\mas2hc\Desktop\data_storage\workspace\ROBFWAIO-OSS/robotframework-testsuitesmanagement/atest/general_config/test_config_level_1.json'.
             - The variant variable is also set with variant name 'variant_1' which is used for configuration level 2 with variant configuration file.
         Please remove input parameter '--variable variant:variant_1' out of the robot run comnand!!!

Test Dotdict Config Params 001                                        | UNKNOWN |
Variable '${CONFIG}' not found. Did you mean:
    ${config_file}

in case variant variable is set in robot run command.
Please help me review and give your feedback if any?

Thank you,
Son