### PR TITLE
add validation for package_context.json

### DIFF
--- a/RobotFramework_TestsuitesManagement/Config/CConfig.py
+++ b/RobotFramework_TestsuitesManagement/Config/CConfig.py
@@ -58,11 +58,27 @@ if os.path.isfile(context_filepath):
     if os.stat(context_filepath).st_size == 0:
         logger.warn(f"The '{context_filepath}' file is existing but empty.")
     else:
+        package_context_schema = {
+            "type": "object",
+            'additionalProperties': False,
+            "properties": {
+                "installer_location": {"type": "string"},
+                "bundle_name": {"type": "string"},
+                "bundle_version": {"type": "string"},
+                "bundle_version_date": {"type": "string"}
+            }
+        }
         try:
             with open(context_filepath) as f:
                 context_config = json.load(f)
         except Exception as reason:
             logger.error(f"Cannot load the '{context_filepath}' file. Reason: {reason}")
+            exit(1)
+        
+        try:
+            validate(instance=context_config, schema=package_context_schema)
+        except Exception as reason:
+            logger.error(f"Invalid '{context_filepath}' file. Reason: {reason}")
             exit(1)
 
         if ('installer_location' in context_config) and context_config['installer_location']:


### PR DESCRIPTION
Hi Thomas,
Hi Holger,

This PR fixes issue #191 .

The `package_context.json` (which is used for AIO package) is generated and added into `robotframework-testsuitesmanagement` automatically by the build pipeline.
This file is a part of this library's source code so that it is no expected to be modified by user.

However, I have added the schema validation for that file to avoid the inconsistence as issue #191 .
The error will be thrown when there is any invalid key in that file.

Please review and give your idea about this change.

Thank you,
Ngoan