### PR TITLE
Htv3hc/feat/trigger other workflow

### DIFF
--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -82,6 +82,7 @@ jobs:
         run: |
           # Get the recently triggered pipeline ID
           PIPELINE_ID=$(gh api repos/test-fullautomation/RobotFramework_AIO/actions/runs --jq '.workflow_runs | sort_by(.created_at) | last | .id')
+          echo $PIPELINE_ID > pipeline_id.txt
 
           # Check the status of the PIPELINE_ID in a loop
           while [[ "$(gh api repos/test-fullautomation/RobotFramework_AIO/actions/runs/$PIPELINE_ID --jq '.status')" != "completed" ]]; do
@@ -92,13 +93,16 @@ jobs:
       - name: Get pipeline result
         id: pipeline
         run: |
+          # Read the PIPELINE_ID from the saved file
+          PIPELINE_ID=$(cat pipeline_id.txt)
+
           # Get result of pipeline AIO
           gh api repos/test-fullautomation/RobotFramework_AIO/actions/runs/$PIPELINE_ID --jq .conclusion > pipeline_status.txt
           gh api repos/test-fullautomation/RobotFramework_AIO/actions/runs/$PIPELINE_ID --jq .html_url > pipeline_link.txt
 
       - name: Report status
         run: |
-          # Read result from file
+          # Read result from the saved file
           PIPELINE_STATUS=$(cat pipeline_status.txt)
           PIPELINE_LINK=$(cat pipeline_link.txt)
 

--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -5,15 +5,6 @@ on:
     tags:
       - "rel/*.*.*"
       - "rel/*.*.*.*"
-  pull_request:
-    types:
-      - closed
-      - opened
-      - synchronize
-    branches: 
-      - develop
-env:
-  GH_TOKEN: ${{ github.token }}
 
 jobs:
   build-n-publish:
@@ -56,63 +47,3 @@ jobs:
             omitNameDuringUpdate: true
             makeLatest: true
             artifacts: dist/*
-
-  trigger-build-aio:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger RobotFramework AIO
-        run: |
-          # Get branch created merge request
-          PULL_REQUEST_BRANCH="${{ github.head_ref }}"
-          curl -X POST https://api.github.com/repos/test-fullautomation/RobotFramework_AIO/dispatches \
-          --header 'authorization: Bearer ${{ secrets.PAT_THONG }}' \
-          -H 'Accept: application/vnd.github.everest-preview+json' \
-          --data '{"event_type": "Triggered by other workflow", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'", "branch": "'"$PULL_REQUEST_BRANCH"'" }}'
-
-  status-build-aio:
-    runs-on: ubuntu-latest
-    needs: trigger-build-aio
-    timeout-minutes: 90  # Timeout after 90 minutes
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Wait for Build AIO Pipeline Completion
-        id: wait-for-pipeline
-        run: |
-          # Get the recently triggered pipeline ID
-          PIPELINE_ID=$(gh api repos/test-fullautomation/RobotFramework_AIO/actions/runs --jq '.workflow_runs | sort_by(.created_at) | last | .id')
-          echo $PIPELINE_ID > pipeline_id.txt
-
-          # Check the status of the PIPELINE_ID in a loop
-          while [[ "$(gh api repos/test-fullautomation/RobotFramework_AIO/actions/runs/$PIPELINE_ID --jq '.status')" != "completed" ]]; do
-            sleep 60  # If not completed, wait for 60 seconds and check again.
-          done
-
-
-      - name: Get pipeline result
-        id: pipeline
-        run: |
-          # Read the PIPELINE_ID from the saved file
-          PIPELINE_ID=$(cat pipeline_id.txt)
-
-          # Get result of pipeline AIO
-          gh api repos/test-fullautomation/RobotFramework_AIO/actions/runs/$PIPELINE_ID --jq .conclusion > pipeline_status.txt
-          gh api repos/test-fullautomation/RobotFramework_AIO/actions/runs/$PIPELINE_ID --jq .html_url > pipeline_link.txt
-
-      - name: Report status
-        run: |
-          # Read result from the saved file
-          PIPELINE_STATUS=$(cat pipeline_status.txt)
-          PIPELINE_LINK=$(cat pipeline_link.txt)
-
-          # Check result pipeline and report
-          if [[ "$PIPELINE_STATUS" == "success" ]]; then
-            echo "Pipeline RobotFramework AIO success."
-            echo "Details at link: $PIPELINE_LINK"
-          else
-            echo "Pipeline RobotFramework AIO is not succeed."
-            echo "Details at link: $PIPELINE_LINK"
-            # Notify fail build AIO pipeline
-            exit 1
-          fi

--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -5,6 +5,13 @@ on:
     tags:
       - "rel/*.*.*"
       - "rel/*.*.*.*"
+  pull_request:
+    types:
+      - closed
+      - opened
+      - synchronize
+    branches: 
+      - develop
 
 jobs:
   build-n-publish:

--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -17,6 +17,7 @@ jobs:
   build-n-publish:
       name: Build and publish to PyPI
       runs-on: ubuntu-latest
+      if: github.event_name == 'push'
 
       steps:
         - name: Checkout source

--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -72,7 +72,7 @@ jobs:
   status-build-aio:
     runs-on: ubuntu-latest
     needs: trigger-build-aio
-    minutes: 90  # Setting timeout for job
+    timeout-minutes: 90  # Timeout after 90 minutes
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -63,7 +63,7 @@ jobs:
           # Get branch created merge request
           PULL_REQUEST_BRANCH="${{ github.head_ref }}"
           curl -X POST https://api.github.com/repos/test-fullautomation/RobotFramework_AIO/dispatches \
-          --header 'authorization: Bearer ${{ secrets.ACTIONS_KEY }}' \
+          --header 'authorization: Bearer ${{ secrets.PAT_THONG }}' \
           -H 'Accept: application/vnd.github.everest-preview+json' \
           --data '{"event_type": "Triggered by other workflow", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'", "branch": "'"$PULL_REQUEST_BRANCH"'" }}'
 

--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -54,3 +54,52 @@ jobs:
             omitNameDuringUpdate: true
             makeLatest: true
             artifacts: dist/*
+
+  trigger-build-aio:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger RobotFramework AIO
+        run: |
+          # Get branch created merge request
+          PULL_REQUEST_BRANCH="${{ github.head_ref }}"
+          curl -X POST https://api.github.com/repos/test-fullautomation/RobotFramework_AIO/dispatches \
+          --header 'authorization: Bearer ${{ secrets.ACTIONS_KEY }}' \
+          -H 'Accept: application/vnd.github.everest-preview+json' \
+          --data '{"event_type": "Triggered by other workflow", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'", "branch": "'"$PULL_REQUEST_BRANCH"'" }}'
+
+  status-build-aio:
+    runs-on: ubuntu-latest
+    needs: trigger-build-aio
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Wait for Build AIO Pipeline Completion
+        id: wait-for-pipeline
+        run: |
+          # Get status build of pipeline AIO
+          while [[ "$(gh api repos/test-fullautomation/RobotFramework_AIO/actions/runs --jq '.workflow_runs | sort_by(.created_at) | last | .status')" != "completed" ]]; do
+            sleep 60  # Wait 60s before check it again
+          done
+
+      - name: Get pipeline result
+        id: pipeline
+        run: |
+          # Get result of pipeline AIO
+          gh api repos/test-fullautomation/RobotFramework_AIO/actions/runs --jq '.workflow_runs | sort_by(.created_at) | last | .conclusion' > pipeline_status.txt
+          gh api repos/test-fullautomation/RobotFramework_AIO/actions/runs --jq '.workflow_runs | sort_by(.created_at) | last | .html_url' > pipeline_link.txt
+
+      - name: Report status
+        run: |
+          # Read result from file
+          pipeline_status=$(cat pipeline_status.txt)
+
+          # Check result pipeline and report
+          if [[ "$pipeline_status" == "success" ]]; then
+            echo "Pipeline RobotFramework AIO success."
+          else
+            echo "Pipeline RobotFramework AIO is not succeed."
+            echo "Details at link: $pipeline_link"
+            # Notify fail build AIO pipeline
+            exit 1
+          fi

--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -80,29 +80,35 @@ jobs:
       - name: Wait for Build AIO Pipeline Completion
         id: wait-for-pipeline
         run: |
-          # Get status build of pipeline AIO
-          while [[ "$(gh api repos/test-fullautomation/RobotFramework_AIO/actions/runs --jq '.workflow_runs | sort_by(.created_at) | last | .status')" != "completed" ]]; do
-            sleep 60  # Wait 60s before check it again
+          # Get the recently triggered pipeline ID
+          PIPELINE_ID=$(gh api repos/test-fullautomation/RobotFramework_AIO/actions/runs --jq '.workflow_runs | sort_by(.created_at) | last | .id')
+
+          # Check the status of the PIPELINE_ID in a loop
+          while [[ "$(gh api repos/test-fullautomation/RobotFramework_AIO/actions/runs/$PIPELINE_ID --jq '.status')" != "completed" ]]; do
+            sleep 60  # If not completed, wait for 60 seconds and check again.
           done
+
 
       - name: Get pipeline result
         id: pipeline
         run: |
           # Get result of pipeline AIO
-          gh api repos/test-fullautomation/RobotFramework_AIO/actions/runs --jq '.workflow_runs | sort_by(.created_at) | last | .conclusion' > pipeline_status.txt
-          gh api repos/test-fullautomation/RobotFramework_AIO/actions/runs --jq '.workflow_runs | sort_by(.created_at) | last | .html_url' > pipeline_link.txt
+          gh api repos/test-fullautomation/RobotFramework_AIO/actions/runs/$PIPELINE_ID --jq .conclusion > pipeline_status.txt
+          gh api repos/test-fullautomation/RobotFramework_AIO/actions/runs/$PIPELINE_ID --jq .html_url > pipeline_link.txt
 
       - name: Report status
         run: |
           # Read result from file
-          pipeline_status=$(cat pipeline_status.txt)
+          PIPELINE_STATUS=$(cat pipeline_status.txt)
+          PIPELINE_LINK=$(cat pipeline_link.txt)
 
           # Check result pipeline and report
-          if [[ "$pipeline_status" == "success" ]]; then
+          if [[ "$PIPELINE_STATUS" == "success" ]]; then
             echo "Pipeline RobotFramework AIO success."
+            echo "Details at link: $PIPELINE_LINK"
           else
             echo "Pipeline RobotFramework AIO is not succeed."
-            echo "Details at link: $pipeline_link"
+            echo "Details at link: $PIPELINE_LINK"
             # Notify fail build AIO pipeline
             exit 1
           fi

--- a/.github/workflows/release_to_pypi.yml
+++ b/.github/workflows/release_to_pypi.yml
@@ -12,6 +12,8 @@ on:
       - synchronize
     branches: 
       - develop
+env:
+  GH_TOKEN: ${{ github.token }}
 
 jobs:
   build-n-publish:
@@ -70,6 +72,7 @@ jobs:
   status-build-aio:
     runs-on: ubuntu-latest
     needs: trigger-build-aio
+    minutes: 90  # Setting timeout for job
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/trigger_aio.yml
+++ b/.github/workflows/trigger_aio.yml
@@ -1,0 +1,73 @@
+name: Trigger RobotFramework AIO
+
+on:
+  pull_request:
+      types:
+          - closed
+          - opened
+          - synchronize
+      branches: 
+          - develop
+env:
+    GH_TOKEN: ${{ github.token }}
+
+jobs:
+  trigger-build-aio:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger RobotFramework AIO
+        run: |
+          # Get branch created merge request
+          PULL_REQUEST_BRANCH="${{ github.head_ref }}"
+          curl -X POST https://api.github.com/repos/test-fullautomation/RobotFramework_AIO/dispatches \
+          --header 'authorization: Bearer ${{ secrets.PAT_THONG }}' \
+          -H 'Accept: application/vnd.github.everest-preview+json' \
+          --data '{"event_type": "TRIGGER_AIO", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'", "branch": "'"$PULL_REQUEST_BRANCH"'" }}'
+
+  status-build-aio:
+    runs-on: ubuntu-latest
+    needs: trigger-build-aio
+    timeout-minutes: 90  # Timeout after 90 minutes
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Wait for Build AIO Pipeline Completion
+        id: wait-for-pipeline
+        run: |
+          # Get the recently triggered pipeline ID
+          PIPELINE_ID=$(gh api repos/test-fullautomation/RobotFramework_AIO/actions/runs --jq '.workflow_runs | sort_by(.created_at) | last | .id')
+          echo $PIPELINE_ID > pipeline_id.txt
+
+          # Check the status of the PIPELINE_ID in a loop
+          while [[ "$(gh api repos/test-fullautomation/RobotFramework_AIO/actions/runs/$PIPELINE_ID --jq '.status')" != "completed" ]]; do
+            sleep 60  # If not completed, wait for 60 seconds and check again.
+          done
+
+
+      - name: Get pipeline result
+        id: pipeline
+        run: |
+          # Read the PIPELINE_ID from the saved file
+          PIPELINE_ID=$(cat pipeline_id.txt)
+
+          # Get result of pipeline AIO
+          gh api repos/test-fullautomation/RobotFramework_AIO/actions/runs/$PIPELINE_ID --jq .conclusion > pipeline_status.txt
+          gh api repos/test-fullautomation/RobotFramework_AIO/actions/runs/$PIPELINE_ID --jq .html_url > pipeline_link.txt
+
+      - name: Report status
+        run: |
+          # Read result from the saved file
+          PIPELINE_STATUS=$(cat pipeline_status.txt)
+          PIPELINE_LINK=$(cat pipeline_link.txt)
+
+          # Check result pipeline and report
+          if [[ "$PIPELINE_STATUS" == "success" ]]; then
+            echo "Pipeline RobotFramework AIO success."
+            echo "Details at link: $PIPELINE_LINK"
+          else
+            echo "Pipeline RobotFramework AIO is not succeed."
+            echo "Details at link: $PIPELINE_LINK"
+            # Notify fail build AIO pipeline
+            exit 1
+          fi


### PR DESCRIPTION
Hi Thomas,

I would like to update code to trigger the build of RobotFramework AIO at this repos following behavior below:
* A new-pull-request, or updated-pull-request coming request to **develop** branch in this repos will trigger **trigger-build-aio** and **status-build-aio**. 
```yaml 
  pull_request:
    types:
      - closed
      - opened
      - synchronize
    branches: 
      - develop
```
* **trigger-build-aio** job will use [Webhook ](https://docs.github.com/en/webhooks/about-webhooks-for-repositories) feature to send a curl POST to **test-fullautomation/RobotFramework_AIO**, and trigger pipeline on it. And it also sends info related to merge request branch and the current repository to request it
```
curl -X POST https://api.github.com/repos/test-fullautomation/RobotFramework_AIO/dispatches \
          --header 'authorization: Bearer ${{ secrets.PAT_THONG }}' \
          -H 'Accept: application/vnd.github.everest-preview+json' \
          --data '{"event_type": "Triggered by other workflow", "client_payload": { "repository": "'"$GITHUB_REPOSITORY"'", "branch": "'"$PULL_REQUEST_BRANCH"'" }}'
```
* **status-build-aio** job will wait the status of the latest pipeline of RobotFramework_AIO until it completely following command below:
```bash
$ gh api repos/test-fullautomation/RobotFramework_AIO/actions/runs --jq '.workflow_runs | sort_by(.created_at) | last | .status'
completed

# Output:
# Case 1: in_progress -> pipeline is running
# Case 2: completed -> pipeline is completed
```
And get the result of pipeline AIO by command below:
```bash
gh api repos/test-fullautomation/RobotFramework_AIO/actions/runs --jq '.workflow_runs | sort_by(.created_at) | last | .conclusion'
success

# Output:
# Case 1: success-> pipeline AIO build is succeed
# Case 2: failure-> pipeline AIO build is failed
```
If the status is **SUCCESS**, we can see the result on this pipeline at Step: Report Status with log info below:
```bash
    echo "Pipeline RobotFramework AIO success."
```
If the status is **FAIL**, we will retrieve the corresponding logs, along with a link to the RobotFramework pipeline results.
```bash
    echo "Pipeline RobotFramework AIO is not succeed."
    echo "Details at link: $pipeline_link"
```
Could you help me review this pull-request? 

Thank you and best regards,
Thong Hua
