### PR TITLE
Added a parameter dump in suite setup based on filter criteria defined in test configuration

### DIFF
--- a/RobotFramework_TestsuitesManagement/Config/CConfig.py
+++ b/RobotFramework_TestsuitesManagement/Config/CConfig.py
@@ -191,9 +191,12 @@ for None so that subclasses will create their own __single objects.
                                 )
 
         # Common configuration parameters
-        self.sWelcomeString  = None
-        self.sTargetName     = None
-        self.dConfigDump     = None
+        self.sWelcomeString = None
+        self.sTargetName    = None
+        self.dConfigDump    = None
+        self.sMachineName   = None
+        self.sUserName      = None
+        self.sBundleVersion = None
 
     def __mergeDicts(self, dMainDict: dict, dUpdateDict: dict) -> dict:
         """
@@ -435,6 +438,10 @@ robot with configuration level 2.")
             BuiltIn().set_suite_metadata("version_hw", self.rMetaData.sVersionHW, top=True)
         if not ("version_test" in suiteMetadata and self.rMetaData.sVersionTest == None):
             BuiltIn().set_suite_metadata("version_test", self.rMetaData.sVersionTest, top=True)
+
+        self.sMachineName   = self.__getMachineName()
+        self.sUserName      = self.__getUserName()
+        self.sBundleVersion = BUNDLE_VERSION
 
         self.oConfigParams = copy.deepcopy(oJsonCfgData)
 

--- a/RobotFramework_TestsuitesManagement/Config/CConfig.py
+++ b/RobotFramework_TestsuitesManagement/Config/CConfig.py
@@ -193,6 +193,7 @@ for None so that subclasses will create their own __single objects.
         # Common configuration parameters
         self.sWelcomeString  = None
         self.sTargetName     = None
+        self.dConfigDump     = None
 
     def __mergeDicts(self, dMainDict: dict, dUpdateDict: dict) -> dict:
         """
@@ -399,6 +400,7 @@ robot with configuration level 2.")
 
         self.sProjectName = oJsonCfgData['Project']
         self.sTargetName = oJsonCfgData['TargetName']
+        self.dConfigDump = oJsonCfgData['ConfigDump']
         self.sWelcomeString = oJsonCfgData['WelcomeString']
         if ("Maximum_version" in oJsonCfgData) and oJsonCfgData["Maximum_version"] != None:
             self.sMaxVersion = oJsonCfgData["Maximum_version"]

--- a/RobotFramework_TestsuitesManagement/Config/configuration_schema.json
+++ b/RobotFramework_TestsuitesManagement/Config/configuration_schema.json
@@ -25,6 +25,9 @@
         }
       }
     },
+    "ConfigDump": {
+      "type": "object"
+    },
     "TargetName": {
       "type": "string"
     },

--- a/RobotFramework_TestsuitesManagement/Config/robot_config.jsonp
+++ b/RobotFramework_TestsuitesManagement/Config/robot_config.jsonp
@@ -29,5 +29,18 @@
     "minorversion" : "6",
     "patchversion" : "0"
   },
-  "TargetName" : "Device_01"
+  "TargetName" : "Device_01",
+  "ConfigDump" : {
+                    // reference: https://github.com/test-fullautomation/python-extensions-collection/blob/develop/PythonExtensionsCollection/PythonExtensionsCollection.pdf
+                    //            section 'String operations with CString', method 'StringFilter'
+                    "casesensitive"    : true,
+                    "startswith"       : null,
+                    "endswith"         : null,
+                    "startsnotwith"    : null,
+                    "endsnotwith"      : null,
+                    "contains"         : null,
+                    "containsnot"      : null,
+                    "inclregex"        : null,
+                    "exclregex"        : null
+                 }
 }

--- a/RobotFramework_TestsuitesManagement/Keywords/CSetup.py
+++ b/RobotFramework_TestsuitesManagement/Keywords/CSetup.py
@@ -16,6 +16,9 @@ import copy
 import os
 
 import RobotFramework_TestsuitesManagement as TM
+
+from RobotframeworkExtensions.Collection import Collection as RFExt
+
 from robot.api.deco import keyword
 from robot.api import logger
 
@@ -108,6 +111,9 @@ checks the version of RobotFramework AIO, and logs out the basic information of 
             logger.info(f"Local config file: '{TM.CTestsuitesCfg.oConfig.sLocalConfig}'")
         logger.info(f"Number of test suites: {TM.CTestsuitesCfg.oConfig.iSuiteCount}")
         logger.info(f"Total number of testcases: {TM.CTestsuitesCfg.oConfig.iTotalTestcases}")
+
+        # dump of all Robot Framework parameters in current scope, based on 'ConfigDump' filter criteria defined in test configuration file
+        RFExt.get_rf_parameters(**TM.CTestsuitesCfg.oConfig.dConfigDump)
 
     @keyword
     def testsuite_teardown(self):

--- a/RobotFramework_TestsuitesManagement/Keywords/CSetup.py
+++ b/RobotFramework_TestsuitesManagement/Keywords/CSetup.py
@@ -113,6 +113,8 @@ checks the version of RobotFramework AIO, and logs out the basic information of 
         logger.info(f"Total number of testcases: {TM.CTestsuitesCfg.oConfig.iTotalTestcases}")
 
         # dump of all Robot Framework parameters in current scope, based on 'ConfigDump' filter criteria defined in test configuration file
+        TM.CTestsuitesCfg.oConfig.dConfigDump['console']  = False
+        TM.CTestsuitesCfg.oConfig.dConfigDump['headline'] = "Robot Framework parameter overview (scope: Test Suite):"
         RFExt.get_rf_parameters(**TM.CTestsuitesCfg.oConfig.dConfigDump)
 
     @keyword

--- a/RobotFramework_TestsuitesManagement/Keywords/CSetup.py
+++ b/RobotFramework_TestsuitesManagement/Keywords/CSetup.py
@@ -112,6 +112,18 @@ checks the version of RobotFramework AIO, and logs out the basic information of 
         logger.info(f"Number of test suites: {TM.CTestsuitesCfg.oConfig.iSuiteCount}")
         logger.info(f"Total number of testcases: {TM.CTestsuitesCfg.oConfig.iTotalTestcases}")
 
+
+        # make some additional useful information global to have them available in the parameter dump
+        BuiltIn().set_global_variable('${LOADED_TSM_CONFIGURATION_FILE}', TM.CTestsuitesCfg.oConfig.sTestCfgFile)
+        BuiltIn().set_global_variable('${PROJECT_NAME}', TM.CTestsuitesCfg.oConfig.sProjectName)
+        BuiltIn().set_global_variable('${VERSION_SW}', TM.CTestsuitesCfg.oConfig.rMetaData.sVersionSW)
+        BuiltIn().set_global_variable('${VERSION_HW}', TM.CTestsuitesCfg.oConfig.rMetaData.sVersionHW)
+        BuiltIn().set_global_variable('${VERSION_TEST}', TM.CTestsuitesCfg.oConfig.rMetaData.sVersionTest)
+        BuiltIn().set_global_variable('${VERSION_ROBFW}', TM.CTestsuitesCfg.oConfig.rMetaData.sROBFWVersion)
+        BuiltIn().set_global_variable('${VERSION_BUNDLE}', TM.CTestsuitesCfg.oConfig.sBundleVersion)
+        BuiltIn().set_global_variable('${MACHINE_NAME}', TM.CTestsuitesCfg.oConfig.sMachineName)
+        BuiltIn().set_global_variable('${USER_NAME}', TM.CTestsuitesCfg.oConfig.sUserName)
+
         # dump of all Robot Framework parameters in current scope, based on 'ConfigDump' filter criteria defined in test configuration file
         TM.CTestsuitesCfg.oConfig.dConfigDump['console']  = False
         TM.CTestsuitesCfg.oConfig.dConfigDump['headline'] = "Robot Framework parameter overview (scope: Test Suite):"

--- a/RobotFramework_TestsuitesManagement/version.py
+++ b/RobotFramework_TestsuitesManagement/version.py
@@ -18,5 +18,5 @@
 #
 # Version and date of package RobotFramework_TestsuitesManagement
 #
-VERSION      = "0.7.10"
-VERSION_DATE = "12.08.2024"
+VERSION      = "0.8.10"
+VERSION_DATE = "18.09.2024"


### PR DESCRIPTION

Requires: https://github.com/test-fullautomation/robotframework-extensions-collection/pull/40

Open:

documentation, history update, 'ConfigDump' subkeys in JSON schema, release notes, selftest adaptions

**This I will add after the changed code is confirmed. Currently it's a proposal only and needs to be reviewed.**
